### PR TITLE
Add MongoDB Support

### DIFF
--- a/cdc-bridge/.gitignore
+++ b/cdc-bridge/.gitignore
@@ -1,0 +1,5 @@
+*.crt
+*.p12
+*.key
+index.js
+*.pem

--- a/cdc-bridge/Dockerfile
+++ b/cdc-bridge/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:16
 
 WORKDIR /usr/src/cdc-bridge
 

--- a/cdc-bridge/index.ts
+++ b/cdc-bridge/index.ts
@@ -1,5 +1,6 @@
 import { Kafka, CompressionTypes, CompressionCodecs, logLevel } from 'kafkajs';
 import * as fs from 'fs';
+import { MongoClient } from 'mongodb';
 import LZ4Codec from 'kafkajs-lz4';
 
 CompressionCodecs[CompressionTypes.LZ4] = new LZ4Codec().codec;
@@ -20,9 +21,14 @@ const kafka = new Kafka({
 
 const consumer = kafka.consumer({ groupId: topic });
 
+const yourConnectionURI = process.env.MONGO_CONNECTION_URI || '';
+
 const run = async () => {
   await consumer.connect();
   await consumer.subscribe({ topic: topic, fromBeginning: true });
+  const client = new MongoClient(yourConnectionURI);
+
+  await client.connect();
 
   await consumer.run({
     eachMessage: async ({ topic, partition, message }) => {

--- a/cdc-bridge/package-lock.json
+++ b/cdc-bridge/package-lock.json
@@ -12,7 +12,7 @@
         "kafkajs": "^2.2.0",
         "kafkajs-lz4": "^2.0.0-beta.0",
         "mongodb": "4.13",
-        "typescript": "^4.8.2"
+        "typescript": "^4.9.4"
       },
       "devDependencies": {
         "@types/node": "18"

--- a/cdc-bridge/package.json
+++ b/cdc-bridge/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "description": "Consumes Ditto Big Peer Kafka Topic and replicates to MongoDB",
   "main": "index.js",
-  "engines": { "node" : "18" },
+  "engines": {
+    "node": "16"
+  },
   "scripts": {
     "watch": "tsc -w",
     "start": "node index.js",
@@ -23,9 +25,8 @@
   "dependencies": {
     "kafkajs": "^2.2.0",
     "kafkajs-lz4": "^2.0.0-beta.0",
-    "typescript": "^4.8.2",
-    "mongodb": "4.13"
-
+    "mongodb": "4.13",
+    "typescript": "^4.9.4"
   },
   "devDependencies": {
     "@types/node": "18"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "devDependencies": {
+    "@types/node": "^18.11.18"
+  },
+  "dependencies": {
+    "kafkajs": "^2.2.3",
+    "kafkajs-lz4": "^2.0.0-beta.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   },
   "dependencies": {
     "kafkajs": "^2.2.3",
-    "kafkajs-lz4": "^2.0.0-beta.0"
+    "kafkajs-lz4": "^2.0.0-beta.0",
+    "mongodb": "^4.13.0"
   }
 }

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,3 @@
+## Integration Test
+
+TODO: ensure that items we're getting from the CDC are correct


### PR DESCRIPTION
fixes https://github.com/getditto/demo-apps/issues/403

- [x] Create a MongoDB instance somewhere
- [x] Keep MongoDB up to date with ditto data using the CDC connector over Kafka and the MongoDB NodeJS api. Follow this guide: https://docs.ditto.live/http/common/guides/kafka/intro
- [ ] Build an Admin Dashboard that calls the MongoDB and Big Peer HTTP API for the same data to show customers that they are the same data